### PR TITLE
Additional debugging for daily questions

### DIFF
--- a/utils/functions/database.js
+++ b/utils/functions/database.js
@@ -150,30 +150,41 @@ async function generateLeaderboard (User, count) {
 }
 
 async function getDailyQuestion(Daily, Ques) {
-
+    
     // attempt to get daily object
     const date = await new Date().toISOString().split('T')[0];
     let question = await Daily.findOne({ date }).exec();
 
-    if(question) {
+    console.log("getDailyQuestion called, date:", date);
 
-        console.log("Inside if-statement, question found");
+    if(question) {
+        console.log("daily question found");
 
         // if daily object exists
         let content = await Ques.findById(question.question).exec();
+
+        console.log(cotent);
+
         return content;
     } else {
 
-        console.log("Inside else-statement, question not found");
+        console.log("daily question not found, generating...");
 
         // if daily object does not exist, create a new one
         const questions = await Ques.find({ rating: { $gte: 2500, $lte: 4000 } }).exec();
         const selection = await questions[Math.floor(Math.random() * questions.length)];
+        
+        console.log("selected problem.");
+        console.log(selection);
 
         let question = await new Daily({
             question: selection._id
         })
+
         await question.save();
+        
+        console.log("created and saved question");
+        console.log(question);
 
         return selection;
     }

--- a/utils/functions/database.js
+++ b/utils/functions/database.js
@@ -177,8 +177,10 @@ async function getDailyQuestion(Daily, Ques) {
         console.log("selected problem.");
         console.log(selection);
 
+        // Manually set daily question date, maybe the defaults are weird?
         let question = await new Daily({
-            question: selection._id
+            question: selection._id,
+            date: date
         })
 
         await question.save();


### PR DESCRIPTION
Added more `console.log`'s and manually set the date for dailyQuestion entries. Trying out other options before someone has to go through the hassle of changing all the async/await's to callbacks.