### PR TITLE
allows for either username or email at login

### DIFF
--- a/database/models/user.js
+++ b/database/models/user.js
@@ -2,8 +2,8 @@ const mongoose = require("mongoose");
 
 // define user schema
 const userSchema = new mongoose.Schema({
-    username: String,
-    ign: String,
+    username: String, //email address
+    ign: String, //username
     hash: String,
     salt: String,
     profile: {

--- a/utils/functions/passport.js
+++ b/utils/functions/passport.js
@@ -13,7 +13,7 @@ module.exports = (app, mongo) => {
             passReqToCallback: true
         }, (req, username, password, cb) => {
             username = username.toLowerCase();
-            mongo.User.find({ username: username }).then((user) => {
+            mongo.User.find({ $or: [ { ign: username }, { username: username } ]}).then((user) => {
                 if (!user[0]) { return cb(null, false); }
 
                 const isValid = validPassword(password, user[0].hash, user[0].salt);

--- a/views/public/signin.ejs
+++ b/views/public/signin.ejs
@@ -33,7 +33,7 @@
 
         <form action="/login" method="post">
             <div class="form-group">
-                <input type="text" class="form-control" id="loginEmail" placeholder="Email Address" name="username">
+                <input type="text" class="form-control" id="loginEmail" placeholder="Username / Email Address" name="username">
             </div>
             <div class="form-group">
                 <input type="password" class="form-control" id="loginPassword" placeholder="Password" name="password">


### PR DESCRIPTION
Fixes #37

 - Adds the conditional logic
 - Adds a comment in the `userSchema` to make it more clear of the contents of the `username` and `ign` property are.
 - Updates the placeholder text to more accurately describe the form fields requirements.