### PR TITLE
Fixes missing names around the site

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -128,7 +128,6 @@ module.exports = (app, mongo) => {
             return; // to prevent ERRHTTPHEADERSSENT
         }
 
-
         const saltHash = genPassword(req.body.password);
 
         const salt = saltHash.salt;
@@ -143,7 +142,7 @@ module.exports = (app, mongo) => {
             hash: hash,
             salt: salt,
             profile: {
-                name: '',
+                name: req.body.ign,
                 location: 'Earth',
                 yob: thisYob,
                 bio: ''

--- a/views/private/class/details.ejs
+++ b/views/private/class/details.ejs
@@ -23,7 +23,7 @@
 <div class="jumbotron container">
     <h1>Student Stats</h1>
     <% students.forEach((student, studentIndex) => { %>
-        <a href="/stats/<%= student.ign %>"><%= student.profile.name %>'s stats</a><br>
+        <a href="/stats/<%= student.ign %>"><%= student.profile.name || student.ign %>'s stats</a><br>
     <% }) %>
 </div>
 

--- a/views/private/profile.ejs
+++ b/views/private/profile.ejs
@@ -190,7 +190,7 @@
 		<div class="col-12 col-md-3 jumbotron">
 			<div class="">
                 
-				<h4><%= user.profile.name ? (user.profile.name.length <= 18 ? user.profile.name : user.profile.name.substring(0, 15)+"...") : "Unnamed User" %></h4>
+				<h4><%= user.profile.name ? (user.profile.name.length <= 18 ? user.profile.name : user.profile.name.substring(0, 15)+"...") : (user.ign.length <= 18 ? user.ign : user.ign.substring(0, 15)+"...") %></h4>
                 
                 <hr class="my-3">
 


### PR DESCRIPTION
fixes #382

- On signup, the profile name is set to the username.
- Stats page falls back to username if the profile name hasn't been set. 
- Profile page falls back to username if the profile name hasn't been set. 