### PR TITLE
Standardized Copyright Footer on All Pages

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,4 +1,8 @@
 <%# This is a footer template %>
+        <div class="container my-5">
+            <footer class="text-center"><br><hr>&copy; The Mu Foundation 2022, a 501(c)(3) nonprofit. All Rights Reserved.<br><a href='/termsOfService#terms-of-service'>Terms of Service</a> | <a href='/termsOfService#privacy-policy'>Privacy Policy</a> | <button type="button" class="btn btn-link" style="padding: 0px; margin-top: -1px;" data-bs-toggle="modal" data-bs-target="#contact-modal">Contact us</button></footer>
+        </div>
+
     </body>
 
     <%# Turn off form autocomplete globally %>

--- a/views/public/index.ejs
+++ b/views/public/index.ejs
@@ -359,7 +359,7 @@
 </div>
 
 <div class="container my-5" data-aos="zoom-out" data-aos-duration="500">
-    <footer class="text-center"><br><hr><br>The Mu Foundation is a 501(c)(3) nonprofit organization.<br>Copyright © 2022 The Mu Foundation. All Rights Reserved.<br><a href='/termsOfService#terms-of-service'>Terms of Service</a> | <a href='/termsOfService#privacy-policy'>Privacy Policy</a> | <button type="button" class="btn btn-link" style="padding: 0px; margin-top: -1px;" data-bs-toggle="modal" data-bs-target="#contact-modal">Contact us</button></footer>
+    <footer class="text-center"><br><hr>&copy; The Mu Foundation 2022, a 501(c)(3) nonprofit. All Rights Reserved.<br><a href='/termsOfService#terms-of-service'>Terms of Service</a> | <a href='/termsOfService#privacy-policy'>Privacy Policy</a> | <button type="button" class="btn btn-link" style="padding: 0px; margin-top: -1px;" data-bs-toggle="modal" data-bs-target="#contact-modal">Contact us</button></footer>
 </div>
 
 <%- include ("../partials/contact") -%>

--- a/views/public/index.ejs
+++ b/views/public/index.ejs
@@ -358,9 +358,5 @@
     <a class="btn btn-lg w-100 btn-secondary mt-2" href="/whoWeAre#joinMutorials" data-aos="fade-up" data-aos-duration="800">Join the Mutorials Team!</a>
 </div>
 
-<div class="container my-5" data-aos="zoom-out" data-aos-duration="500">
-    <footer class="text-center"><br><hr>&copy; The Mu Foundation 2022, a 501(c)(3) nonprofit. All Rights Reserved.<br><a href='/termsOfService#terms-of-service'>Terms of Service</a> | <a href='/termsOfService#privacy-policy'>Privacy Policy</a> | <button type="button" class="btn btn-link" style="padding: 0px; margin-top: -1px;" data-bs-toggle="modal" data-bs-target="#contact-modal">Contact us</button></footer>
-</div>
-
 <%- include ("../partials/contact") -%>
 <%- include("../partials/footer") -%>

--- a/views/public/termsOfService.ejs
+++ b/views/public/termsOfService.ejs
@@ -58,4 +58,6 @@
         <li>We follow extra precautions for our users who are under 13. This includes restricting child accounts to features that do not let them disclose personal information.</li>
     </ol>
     <p>We reserve the right to change this Privacy Policy without notice. However, we will add a notification to the site when this Privacy Policy changes.</p>
+</div>
+
 <%- include("../partials/footer") -%>


### PR DESCRIPTION
* Copyright footer now adheres to standard copyright footers seen on websites
    * **Old:** The Mu Foundation is a 501(c)(3) nonprofit organization. Copyright © 2022 The Mu Foundation. All Rights Reserved.
    * **New:** &copy; The Mu Foundation 2022, a 501(c)(3) nonprofit. All Rights Reserved.
* Copyright footer is shown on all pages under mutorials.org (added it to the footer template)
* AOS zoom is now removed for copyright footer **only** (@womogenes said yes)