### PR TITLE
Update roles for '25-26

### DIFF
--- a/views/public/teamV2.ejs
+++ b/views/public/teamV2.ejs
@@ -69,11 +69,6 @@
           <div class="personElement">
             <div class="imageElement">
               <img src="https://cdn.mutorials.org/profiles/nihal.png" alt="person" class="personImage">
-              <div class="socialLinks">
-                <a href="mailto:president@mutorials.org" target="_blank">
-                  <span class="material-symbols-outlined icon">mail</span>
-                </a>
-              </div>
             </div>
             <div class="text">
               <p class="personName">Nihal Josyula</p>
@@ -84,11 +79,6 @@
           <div class="personElement">
             <div class="imageElement">
               <img src="https://cdn.mutorials.org/profiles/patrick.png" alt="person" class="personImage">
-              <div class="socialLinks">
-                <a href="mailto:admin@mutorials.org" target="_blank">
-                  <span class="material-symbols-outlined icon">mail</span>
-                </a>
-              </div>
             </div>
             <div class="text">
               <p class="personName">Patrick Feng</p>
@@ -99,11 +89,6 @@
           <div class="personElement">
             <div class="imageElement">
               <img src="https://cdn.mutorials.org/profiles/devesh.jpeg" alt="person" class="personImage">
-              <div class="socialLinks">
-                <a href="mailto:content@mutorials.org" target="_blank">
-                  <span class="material-symbols-outlined icon">mail</span>
-                </a>
-              </div>
             </div>
             <div class="text">
               <p class="personName">Devesh Aggarwal</p>
@@ -115,11 +100,6 @@
           <div class="personElement">
             <div class="imageElement">
               <img src="https://cdn.mutorials.org/profiles/brian.jpg" alt="person" class="personImage">
-              <div class="socialLinks">
-                <a href="mailto:marketing@mutorials.org" target="_blank">
-                  <span class="material-symbols-outlined icon">mail</span>
-                </a>
-              </div>
             </div>
             <div class="text">
               <p class="personName">Brian He</p>
@@ -137,11 +117,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/William.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:president@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">William Y. Feng</p>
@@ -152,11 +127,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/patrick.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:admin@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Patrick Feng</p>
@@ -167,11 +137,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Daniel.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:secretary@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Daniel Lu</p>
@@ -182,11 +147,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/nihal.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:content@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Nihal Josyula</p>
@@ -198,11 +158,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Grace.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:marketing@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Grace Chen</p>
@@ -221,11 +176,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Arya.jpg" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:president@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Arya Gummadi</p>
@@ -236,11 +186,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/William.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:admin@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">William Y. Feng</p>
@@ -251,11 +196,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Daniel.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:secretary@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Daniel Lu</p>
@@ -266,11 +206,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Ishaan.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:design@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Ishaan Venkat</p>
@@ -282,11 +217,6 @@
           <div class="imageElement">
             <!-- Profile image removed -->
             <img src="https://cdn.mutorials.org/profiles/nihal.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:content@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Nihal Josyula</p>
@@ -297,11 +227,6 @@
         <div class="personElement">
           <div class="imageElement">
             
-            <div class="socialLinks">
-              <a href="mailto:content@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Jaewon Chung</p>
@@ -312,11 +237,6 @@
         <div class="personElement">
           <div class="imageElement">
             <img src="https://cdn.mutorials.org/profiles/Grace.png" alt="person" class="personImage">
-            <div class="socialLinks">
-              <a href="mailto:marketing@mutorials.org" target="_blank">
-                <span class="material-symbols-outlined icon">mail</span>
-              </a>
-            </div>
           </div>
           <div class="text">
             <p class="personName">Grace Chen</p>

--- a/views/public/teamV2.ejs
+++ b/views/public/teamV2.ejs
@@ -311,7 +311,7 @@
         </div>
         <div class="personElement">
           <div class="imageElement">
-            <img src="https://cdn.mutorials.org/profiles/Ishaan.png" alt="person" class="personImage">
+            <img src="https://cdn.mutorials.org/profiles/Grace.png" alt="person" class="personImage">
             <div class="socialLinks">
               <a href="mailto:marketing@mutorials.org" target="_blank">
                 <span class="material-symbols-outlined icon">mail</span>

--- a/views/public/teamV2.ejs
+++ b/views/public/teamV2.ejs
@@ -14,7 +14,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div class="personElement">
         <div class="imageElement">
-          <img src="https://cdn.mutorials.org/profiles/nihal.png" alt="person" class="personImage">
+          <img src="https://cdn.mutorials.org/profiles/devesh.jpeg" alt="person" class="personImage">
           <div class="socialLinks">
             <a href="mailto:president@mutorials.org" target="_blank">
               <span class="material-symbols-outlined icon">mail</span>
@@ -22,9 +22,9 @@
           </div>
         </div>
         <div class="text">
-          <p class="personName">Nihal Josyula</p>
+          <p class="personName">Devesh Aggarwal</p>
           <p class="personTitle">President</p>
-          <p class="personDesc">Nihal manages the organization, providing overall direction while effectively leading the strategy and long-term vision of the Mu Foundation.</p>
+          <p class="personDesc">Devesh manages the organization, providing overall direction while effectively leading the strategy and long-term vision of the Mu Foundation.</p>
         </div>
       </div>
       <div class="personElement">
@@ -45,22 +45,6 @@
       
       <div class="personElement">
         <div class="imageElement">
-          <img src="https://cdn.mutorials.org/profiles/devesh.jpeg" alt="person" class="personImage">
-          <div class="socialLinks">
-            <a href="mailto:content@mutorials.org" target="_blank">
-              <span class="material-symbols-outlined icon">mail</span>
-            </a>
-          </div>
-        </div>
-        <div class="text">
-          <p class="personName">Devesh Aggarwal</p>
-          <p class="personTitle">Director of Content Development</p>
-          <p class="personDesc">Devesh manages content development and review, overseeing all contributors. He aims to enhance the content experience for users and expand the inventory of high-quality questions.
-          </p>
-        </div>
-      </div>
-      <div class="personElement">
-        <div class="imageElement">
           <img src="https://cdn.mutorials.org/profiles/brian.jpg" alt="person" class="personImage">
           <div class="socialLinks">
             <a href="mailto:marketing@mutorials.org" target="_blank">
@@ -77,6 +61,74 @@
     </div>
 
     <div class="mt-8">
+      <details>
+        <summary class="mb-2">
+          <h3 class="inline cursor-pointer">Former Board of Directors (2024-2025)</h3>
+        </summary>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="personElement">
+            <div class="imageElement">
+              <img src="https://cdn.mutorials.org/profiles/nihal.png" alt="person" class="personImage">
+              <div class="socialLinks">
+                <a href="mailto:president@mutorials.org" target="_blank">
+                  <span class="material-symbols-outlined icon">mail</span>
+                </a>
+              </div>
+            </div>
+            <div class="text">
+              <p class="personName">Nihal Josyula</p>
+              <p class="personTitle">Former President</p>
+              <p class="personDesc">Nihal manages the organization, providing overall direction while effectively leading the strategy and long-term vision of the Mu Foundation.</p>
+            </div>
+          </div>
+          <div class="personElement">
+            <div class="imageElement">
+              <img src="https://cdn.mutorials.org/profiles/patrick.png" alt="person" class="personImage">
+              <div class="socialLinks">
+                <a href="mailto:admin@mutorials.org" target="_blank">
+                  <span class="material-symbols-outlined icon">mail</span>
+                </a>
+              </div>
+            </div>
+            <div class="text">
+              <p class="personName">Patrick Feng</p>
+              <p class="personTitle">Director of Software Development</p>
+              <p class="personDesc">As Director of Software Development, Patrick maintains the codebase, implements new features, and facilitates code contribution at Mutorials.</p>
+            </div>
+          </div>
+          <div class="personElement">
+            <div class="imageElement">
+              <img src="https://cdn.mutorials.org/profiles/devesh.jpeg" alt="person" class="personImage">
+              <div class="socialLinks">
+                <a href="mailto:content@mutorials.org" target="_blank">
+                  <span class="material-symbols-outlined icon">mail</span>
+                </a>
+              </div>
+            </div>
+            <div class="text">
+              <p class="personName">Devesh Aggarwal</p>
+              <p class="personTitle">Director of Content Development</p>
+              <p class="personDesc">Devesh manages content development and review, overseeing all contributors. He aims to enhance the content experience for users and expand the inventory of high-quality questions.
+              </p>
+            </div>
+          </div>
+          <div class="personElement">
+            <div class="imageElement">
+              <img src="https://cdn.mutorials.org/profiles/brian.jpg" alt="person" class="personImage">
+              <div class="socialLinks">
+                <a href="mailto:marketing@mutorials.org" target="_blank">
+                  <span class="material-symbols-outlined icon">mail</span>
+                </a>
+              </div>
+            </div>
+            <div class="text">
+              <p class="personName">Brian He</p>
+              <p class="personTitle">Director of Marketing</p>
+              <p class="personDesc" style="margin-bottom: 10px;">Brian oversees the outreach work at Mutorials and forms partnerships with other organizations and schools.</p>
+            </div>
+          </div>
+        </div>
+      </details>
       <details>
         <summary class="mb-2">
           <h3 class="inline cursor-pointer">Former Board of Directors (2023-2024)</h3>
@@ -123,7 +175,7 @@
           </div>
           <div class="text">
             <p class="personName">Daniel Lu</p>
-            <p class="personTitle">Secretary</p>
+            <p class="personTitle">Former Secretary</p>
             <p class="personDesc">Daniel oversees all the processes at Mutorials and organizes most events and meetings. He is also responsible for assigning tasks and keeping the organization in check.</p>
           </div>
         </div>
@@ -207,7 +259,7 @@
           </div>
           <div class="text">
             <p class="personName">Daniel Lu</p>
-            <p class="personTitle">Secretary</p>
+            <p class="personTitle">Former Secretary</p>
             <p class="personDesc">Daniel oversees all the processes at Mutorials and organizes most events and meetings. He is also responsible for assigning tasks and keeping the organization in check.</p>
           </div>
         </div>


### PR DESCRIPTION
Also fixed minor bugs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the team page to reflect 2025–2026 leadership (Devesh as President), adds a 2024–2025 Former Board section, adjusts prior-year titles, removes old mail links, and fixes an image.
> 
> - **Team page (views/public/teamV2.ejs)**:
>   - **Current Board (2025–2026)**: Set `President` to `Devesh Aggarwal` with updated image/description; removed current `Director of Content Development` card for Devesh.
>   - **New section**: Added `Former Board of Directors (2024–2025)` with entries for `Nihal Josyula` (Former President), `Patrick Feng`, `Devesh Aggarwal` (Director of Content Development), and `Brian He`.
>   - **Former Boards cleanup**:
>     - 2023–2024 and 2022–2023: Changed `Daniel Lu` title to `Former Secretary` where applicable.
>     - Removed `socialLinks` mail icons/links from multiple former entries.
>     - Corrected `Grace Chen` image in the 2022–2023 section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f156b0fad6980c22ab6fad6e5d86e11af37344a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->