### PR TITLE
tailwind v2 migration: settings, leaderboard, stats

### DIFF
--- a/routes/settings.js
+++ b/routes/settings.js
@@ -2,6 +2,8 @@
 const { genPassword, validPassword } = require('../utils/functions/password');
 const emailValidation = require('../utils/functions/emailValidation');
 
+const expressLayouts = require('express-ejs-layouts');
+
 const VIEWS = __dirname + '/../views/';
 
 module.exports = (app, mongo) => {
@@ -286,10 +288,11 @@ module.exports = (app, mongo) => {
     }
   });
 
-  app.get('/settings', (req, res) => {
-    res.render(VIEWS + 'private/settings.ejs', {
+  app.get('/settings', expressLayouts, (req, res) => {
+    res.render(VIEWS + 'private/settingsV2.ejs', {
       user: req.user,
       pageName: 'Settings',
+      layout: 'layouts/base.ejs',
     });
   });
 };

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -24,11 +24,12 @@ module.exports = (app, mongo) => {
     }
   });
 
-  app.get('/leaderboard', async (req, res) => {
+  app.get('/leaderboard', expressLayouts, async (req, res) => {
     const leaderboard = await generateLeaderboard(mongo.User, 10);
-    res.render(VIEWS + 'private/leaderboard.ejs', {
+    res.render(VIEWS + 'private/leaderboardV2.ejs', {
       rankings: leaderboard,
       pageName: 'Leaderboard',
+      layout: 'layouts/base.ejs',
     });
   });
 

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -126,7 +126,7 @@ module.exports = (app, mongo) => {
     }
   });
 
-  app.get('/stats/:username', (req, res) => {
+  app.get('/stats/:username', expressLayouts, (req, res) => {
     mongo.User.findOne({ ign: req.params.username }, async function (err, obj) {
       if (obj) {
         if (
@@ -147,12 +147,13 @@ module.exports = (app, mongo) => {
                 obj.stats.units ? obj.stats.units : {}
               );
 
-              res.render(VIEWS + 'private/stats.ejs', {
+              res.render(VIEWS + 'private/statsV2.ejs', {
                 user: obj,
                 totalTags: tags,
                 userLevel,
                 analytics,
                 pageName: obj.ign + "'s Stats",
+                layout: 'layouts/base.ejs',
               });
             } else {
               req.flash(
@@ -168,12 +169,13 @@ module.exports = (app, mongo) => {
           );
           let analytics = await analyze(obj.stats.units ? obj.stats.units : {});
 
-          res.render(VIEWS + 'private/stats.ejs', {
+          res.render(VIEWS + 'private/statsV2.ejs', {
             user: obj,
             totalTags: tags,
             userLevel,
             analytics,
             pageName: obj.ign + "'s Stats",
+            layout: 'layouts/base.ejs',
           });
         }
       } else {

--- a/views/private/leaderboardV2.ejs
+++ b/views/private/leaderboardV2.ejs
@@ -1,0 +1,138 @@
+<%
+  const rankBg = (r) => {
+    if (r === 1) return 'bg-sky-500 text-white';
+    if (r === 2) return 'bg-yellow-400';
+    if (r === 3) return 'bg-red-500 text-white';
+    return 'bg-green-500 text-white';
+  };
+  const medalSrc = (r) => {
+    if (r === 1) return 'https://cdn.mutorials.org/images/icons/Leaderboard_First.svg';
+    if (r === 2) return 'https://cdn.mutorials.org/images/icons/Leaderboard_Second.svg';
+    if (r === 3) return 'https://cdn.mutorials.org/images/icons/Leaderboard_Third.svg';
+    return null;
+  };
+  const truncate = (s, n) => s.length <= n ? s : s.substring(0, n - 3) + '...';
+%>
+
+<%- contentFor('main') %>
+<div class="flex flex-col items-center w-full max-w-6xl px-6 py-8 gap-10">
+
+  <h1 class="text-4xl sm:text-5xl text-center">Rating Leaderboard</h1>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 w-full">
+    <% [
+      ['Physics',   rankings.physics, (u) => u.rating.physics],
+      ['Chemistry', rankings.chem,    (u) => u.rating.chemistry],
+      ['Biology',   rankings.bio,     (u) => u.rating.biology],
+      ['USABO',     rankings.usabo,   (u) => u.rating.usabo],
+    ].forEach(([title, list, getValue]) => { %>
+      <div class="p-4 rounded-xl border-2">
+        <h3 class="text-center mb-3"><%= title %></h3>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm text-center">
+            <thead class="bg-neutral-100">
+              <tr>
+                <th>Rank</th>
+                <th>Username</th>
+                <th>Rating</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% let rank = 1; %>
+              <% list.forEach((user) => { %>
+                <tr class="<%= rankBg(rank) %>">
+                  <th scope="row">
+                    <% const medal = medalSrc(rank); %>
+                    <% if (medal) { %>
+                      <img src="<%= medal %>" width="25" height="25" class="inline-block align-top" alt="">
+                    <% } else { %>
+                      <%= rank %>
+                    <% } %>
+                  </th>
+                  <td><a class="no-underline hover:underline" href="/profile/<%= user.ign %>" target="_blank"><%= truncate(user.ign, 15) %></a></td>
+                  <td><%= getValue(user) %></td>
+                </tr>
+                <% rank++; %>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% }) %>
+  </div>
+
+  <h1 class="text-4xl sm:text-5xl text-center mt-6">Problem Rush Leaderboard</h1>
+
+  <div class="w-full lg:max-w-3xl mx-auto p-4 rounded-xl border-2">
+    <h3 class="text-center mb-3">Highest Rush Scores</h3>
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm text-center">
+        <thead class="bg-neutral-100">
+          <tr>
+            <th>Rank</th>
+            <th>Username</th>
+            <th>High Score</th>
+            <th>Attempts</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% let rankRush = 1; %>
+          <% rankings.rush.forEach((user) => { %>
+            <tr class="<%= rankBg(rankRush) %>">
+              <th scope="row">
+                <% const medal = medalSrc(rankRush); %>
+                <% if (medal) { %>
+                  <img src="<%= medal %>" width="25" height="25" class="inline-block align-top" alt="">
+                <% } else { %>
+                  <%= rankRush %>
+                <% } %>
+              </th>
+              <td><a class="no-underline hover:underline" href="/profile/<%= user.ign %>" target="_blank"><%= truncate(user.ign, 33) %></a></td>
+              <td><%= user.stats.rush.highscore %></td>
+              <td><%= user.stats.rush.attempts %></td>
+            </tr>
+            <% rankRush++; %>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <h1 class="text-4xl sm:text-5xl text-center mt-6">Experience Leaderboard</h1>
+
+  <div class="w-full lg:max-w-3xl mx-auto p-4 rounded-xl border-2">
+    <h3 class="text-center mb-3">Highest Level Mutorials Users</h3>
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm text-center">
+        <thead class="bg-neutral-100">
+          <tr>
+            <th>Rank</th>
+            <th>Username</th>
+            <th>Level</th>
+            <th>Experience</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% let rankExp = 1; %>
+          <% rankings.experience.forEach((user) => { %>
+            <tr class="<%= rankBg(rankExp) %>">
+              <th scope="row">
+                <% const medal = medalSrc(rankExp); %>
+                <% if (medal) { %>
+                  <img src="<%= medal %>" width="25" height="25" class="inline-block align-top" alt="">
+                <% } else { %>
+                  <%= rankExp %>
+                <% } %>
+              </th>
+              <td><a class="no-underline hover:underline" href="/profile/<%= user.ign %>" target="_blank"><%= truncate(user.ign, 33) %></a></td>
+              <td><%= user.level.level %></td>
+              <td><%= Math.round(user.experience) %></td>
+            </tr>
+            <% rankExp++; %>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</div>

--- a/views/private/settingsV2.ejs
+++ b/views/private/settingsV2.ejs
@@ -1,0 +1,175 @@
+<%- contentFor('main') %>
+<div
+  class="flex flex-col items-stretch w-full max-w-3xl px-6 py-8 gap-6"
+  x-data="{ unsaved: false, showDeleteConfirm: false, showPwReq: false }"
+>
+  <h1 class="text-4xl sm:text-5xl">Settings</h1>
+
+  <div
+    x-show="unsaved"
+    x-cloak
+    x-transition
+    class="px-4 py-2 rounded border-2 border-orange-300 bg-orange-50 text-orange-900"
+  >
+    Careful! You have unsaved changes!
+  </div>
+
+  <%# Profile %>
+  <form action="/changeProfile" method="POST" class="p-6 rounded-xl border-2 flex flex-col gap-4">
+    <h3 class="text-xl font-medium">Profile</h3>
+
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="name" class="sm:col-span-3 font-medium">Name</label>
+      <input
+        type="text" id="name" name="name"
+        class="sm:col-span-9"
+        value="<%= user.profile.name %>" placeholder="Enter your name here"
+        @input="unsaved = true"
+      >
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="bio" class="sm:col-span-3 font-medium">Bio</label>
+      <input
+        type="text" id="bio" name="bio"
+        class="sm:col-span-9"
+        value="<%= user.profile.bio %>" placeholder="Introduce yourself!"
+        @input="unsaved = true"
+      >
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="location" class="sm:col-span-3 font-medium">Location</label>
+      <input
+        type="text" id="location" name="location"
+        class="sm:col-span-9"
+        value="<%= user.profile.location %>" placeholder="Where do you live?"
+        @input="unsaved = true"
+      >
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="yob" class="sm:col-span-3 font-medium">Year of Birth</label>
+      <input
+        type="number" id="yob" name="yob"
+        class="sm:col-span-9"
+        value="<%= user.profile.yob %>" placeholder="Enter your year of birth here"
+        @input="unsaved = true"
+      >
+    </div>
+
+    <input class="btn btn-primary self-start" type="submit" value="Update Profile">
+  </form>
+
+  <%# Personalization %>
+  <form action="/changePreferences" method="POST" class="p-6 rounded-xl border-2 flex flex-col gap-4">
+    <h3 class="text-xl font-medium">Personalization</h3>
+
+    <label class="flex items-center gap-2">
+      <input type="checkbox" id="darkMode" name="darkMode" <% if (locals.darkMode) { %>checked<% } %>>
+      <span>Dark Mode</span>
+    </label>
+    <label class="flex items-center gap-2">
+      <input type="checkbox" id="hideProfile" name="hideProfile" <% if (user.preferences.hideProfile) { %>checked<% } %>>
+      <span>Hide Public Profile and Stats</span>
+    </label>
+
+    <input class="btn btn-primary self-start" type="submit" value="Update Preferences">
+  </form>
+
+  <%# Account %>
+  <form action="/changeSettings" method="POST" class="p-6 rounded-xl border-2 flex flex-col gap-4">
+    <h3 class="text-xl font-medium">Account</h3>
+
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="ign" class="sm:col-span-3 font-medium">Username</label>
+      <input
+        type="text" id="ign" name="ign"
+        class="sm:col-span-9"
+        value="<%= user.ign %>" placeholder="Change your username"
+        @input="unsaved = true"
+      >
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="username" class="sm:col-span-3 font-medium">Email</label>
+      <input
+        type="text" id="username" name="username"
+        class="sm:col-span-9"
+        value="<%= user.username %>" placeholder="Change your linked email"
+        @input="unsaved = true"
+      >
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="plassword" class="sm:col-span-3 font-medium">Change Password</label>
+      <input
+        type="password" id="plassword" name="plassword"
+        class="sm:col-span-9"
+        placeholder="Current password"
+      >
+      <div class="hidden sm:block sm:col-span-3"></div>
+      <input
+        type="password" id="newpw" name="newpw"
+        class="sm:col-span-9"
+        placeholder="New password"
+        @focus="showPwReq = true"
+        @blur="setTimeout(() => showPwReq = false, 1000)"
+      >
+      <div class="hidden sm:block sm:col-span-3"></div>
+      <input
+        type="password" id="password" name="confirmnewpw"
+        class="sm:col-span-9"
+        placeholder="Confirm new password"
+      >
+      <p
+        x-show="showPwReq"
+        x-cloak
+        x-transition
+        class="sm:col-span-12 text-sm"
+      >
+        A valid password must have a minimum of <strong>7 characters</strong> which includes at least <strong>1 letter</strong> and at least <strong>1 number</strong>.
+      </p>
+    </div>
+
+    <input class="btn btn-primary self-start" type="submit" value="Update Account">
+  </form>
+
+  <%# Delete Account %>
+  <form id="delete-account-form" action="/deleteAccount" method="POST" class="p-6 rounded-xl border-2 flex flex-col gap-4">
+    <h3 class="text-xl font-medium">Delete Account</h3>
+
+    <div class="grid grid-cols-1 sm:grid-cols-12 sm:items-center gap-2">
+      <label for="delassword" class="sm:col-span-3 font-medium">Password</label>
+      <input
+        type="password" id="delassword" name="delassword"
+        class="sm:col-span-9"
+        placeholder="Current password"
+      >
+    </div>
+
+    <button
+      type="button"
+      class="btn bg-red-600 hover:bg-red-700 text-white self-start"
+      @click="showDeleteConfirm = true"
+    >Delete Account</button>
+  </form>
+
+  <%# Confirm-delete modal %>
+  <div
+    x-show="showDeleteConfirm"
+    x-cloak
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    @click.self="showDeleteConfirm = false"
+    @keydown.escape.window="showDeleteConfirm = false"
+  >
+    <div class="bg-white rounded-xl shadow-lg max-w-sm w-full mx-4 overflow-hidden">
+      <div class="px-6 py-4 border-b font-medium">Confirm Delete Account</div>
+      <div class="px-6 py-4">Are you sure you want to delete your account?</div>
+      <div class="px-6 py-4 border-t flex justify-end gap-2">
+        <button type="button" class="btn btn-outline" @click="showDeleteConfirm = false">Cancel</button>
+        <button
+          type="button"
+          class="btn bg-red-600 hover:bg-red-700 text-white"
+          @click="document.getElementById('delete-account-form').submit()"
+        >Delete</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/private/statsV2.ejs
+++ b/views/private/statsV2.ejs
@@ -1,0 +1,247 @@
+<%
+  // [displayName, ratingKey, analyticsKey, proficiencyPathSegment, hasCollectedTags]
+  const subjects = [
+    ['Physics',   'physics',   'physics',   'physics',   true],
+    ['Chemistry', 'chemistry', 'chemistry', 'chemistry', true],
+    ['Biology',   'biology',   'biology',   'biology',   true],
+    ['ESS',       'ess',       'ess',       'ess',       true],
+    ['USABO',     'usabo',     'usabo',     'USABO',     false],
+  ];
+%>
+
+<%- contentFor('head') %>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.min.js"></script>
+<script>
+  $(document).ready(function () {
+    let physicsRating   = parseInt('<%= user.rating.physics %>');
+    let chemistryRating = parseInt('<%= user.rating.chemistry %>');
+    let biologyRating   = parseInt('<%= user.rating.biology %>');
+    let essRating       = parseInt('<%= user.rating.ess %>');
+    let usaboRating     = parseInt('<%= user.rating.usabo %>');
+    let experience      = parseInt('<%= user.stats.experience ? user.stats.experience : 0 %>');
+    let rushHighscore   = parseInt('<%= user.stats.rush.highscore ? user.stats.rush.highscore : 0 %>');
+
+    $.get('/statsAdditional', { physicsRating, chemistryRating, biologyRating, essRating, usaboRating, experience, rushHighscore }, (data) => {
+      if (data.status == 'Success') {
+        $('#physics-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.physics + '</span>');
+        $('#chemistry-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.chemistry + '</span>');
+        $('#biology-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.biology + '</span>');
+        $('#ess-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.ess + '</span>');
+        $('#usabo-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.usabo + '</span>');
+        $('#experience-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.experience + '</span>');
+        $('#rush-global-rank').html('Global Rank: <span class="text-blue-600">#' + data.globalRank.rush + '</span>');
+      }
+    });
+  });
+
+  window.addEventListener('load', function () {
+    Chart.pluginService.register({
+      beforeDraw: function (chart) {
+        if (chart.config.options.correctwrongPlugin) {
+          var width = chart.chart.width;
+          var height = chart.chart.height;
+          var ctx = chart.chart.ctx;
+          ctx.restore();
+          ctx.font = '1.5em sans-serif';
+          ctx.fillStyle = '#8d0f0f';
+          var text = 'Wrong: <%= user.stats.correct + user.stats.wrong != 0 ? Math.round(100 * user.stats.wrong / (user.stats.correct + user.stats.wrong)) : 0 %>%';
+          var textX = Math.round((width - ctx.measureText(text).width) / 2);
+          var textY = (height / 2) + 25;
+          ctx.fillText(text, textX, textY);
+          ctx.fillStyle = '#208d0f';
+          text = 'Correct: <%= user.stats.correct + user.stats.wrong != 0 ? Math.round(100 * user.stats.correct / (user.stats.correct + user.stats.wrong)) : 0 %>%';
+          textX = Math.round((width - ctx.measureText(text).width) / 2);
+          textY -= 30;
+          ctx.fillText(text, textX, textY);
+          ctx.save();
+        }
+      }
+    });
+
+    var ctxPassrate = document.getElementById('correctWrongChart');
+    new Chart(ctxPassrate, {
+      type: 'pie',
+      data: {
+        labels: ['Correct', 'Wrong'],
+        datasets: [{
+          label: 'User Correct/Wrong Counts',
+          data: [
+            parseInt($('#correctcount').val()) + parseInt($('#wrongcount').val()) != 0 ? $('#correctcount').val() : 1,
+            $('#wrongcount').val()
+          ],
+          backgroundColor: ['rgba(80, 185, 20, 1)', 'rgba(215, 80, 80, 1)'],
+          hoverBackgroundColor: ['rgba(80, 185, 20, 1)', 'rgba(215, 80, 80, 1)'],
+          borderColor: ['rgba(255, 255, 255, 0.5)', 'rgba(255, 255, 255, 0.5)'],
+          borderWidth: 2
+        }]
+      },
+      options: {
+        correctwrongPlugin: true,
+        title: { display: true, text: 'User Correct/Wrong Counts' },
+        legend: { display: false },
+        cutoutPercentage: 60,
+        responsive: true,
+        maintainAspectRatio: false,
+      }
+    });
+
+    ['Physics', 'Chemistry', 'Biology', 'ESS', 'USABO'].forEach((subject) => {
+      var ctxTracker = document.getElementById('ratingTrackerChart-' + subject);
+      var tracker = $('#ratingTrackerArray-' + subject).val().split('@');
+      if (tracker.length < 2) tracker.unshift(tracker[0]);
+      var labels = [];
+      for (var i = tracker.length; i > 0; i--) labels.push(i + ' Problems Ago');
+      labels.push('');
+
+      let color = (subject == 'Physics')   ? 'rgba(100, 200, 230, 1)' :
+                  (subject == 'Chemistry') ? 'rgba(245, 170,  40, 1)' :
+                  (subject == 'Biology')   ? 'rgba( 40, 240, 110, 1)' :
+                  (subject == 'ESS')       ? 'rgba(184, 150, 191, 1)' :
+                                             'rgba(113,  16,   1, 1)';
+
+      new Chart(ctxTracker, {
+        type: 'line',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Rating History',
+            data: tracker,
+            backgroundColor: color,
+            borderColor: color,
+            fill: false,
+            borderWidth: 4,
+          }]
+        },
+        options: {
+          title: { display: true, text: subject + ' Rating Tracker' },
+          legend: { display: false },
+          scales: {
+            yAxes: [{
+              ticks: {
+                min: Math.round((Math.min.apply(null, tracker) - 50) / 50) * 50,
+                max: Math.round((Math.max.apply(null, tracker) + 50) / 50) * 50,
+                stepSize: 50,
+              }
+            }],
+            xAxes: [{ ticks: { display: false } }]
+          },
+          responsive: true,
+          maintainAspectRatio: false,
+        }
+      });
+    });
+  });
+</script>
+
+<%- contentFor('main') %>
+<div class="flex flex-col items-stretch w-full max-w-4xl px-6 py-8 gap-6">
+
+  <h1 class="text-3xl sm:text-4xl">
+    <strong><a class="prose" target="_blank" href="/profile/<%= user.ign %>"><%= user.ign %></a></strong>'s Stats
+  </h1>
+
+  <% subjects.forEach(([display, ratingKey, akey, profPath, hasTags]) => { %>
+    <div class="p-6 rounded-xl border-2 flex flex-col gap-4">
+
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-4">
+
+        <%# Left: rating + global rank + tags + analytics tags %>
+        <div class="lg:col-span-7 flex flex-col gap-2">
+          <h2 class="text-3xl"><%= display %>:
+            <span class="text-green-600"><%= user.rating[ratingKey] != -1 ? user.rating[ratingKey] : 'Unrated' %></span>
+          </h2>
+          <h3 class="text-xl" id="<%= akey %>-global-rank">Global Rank: XXX</h3>
+
+          <% if (hasTags) { %>
+            <h4 class="text-base font-medium mt-2">Collected <%= display %> Tags:</h4>
+            <div class="flex flex-wrap gap-2">
+              <% let counter = 0; %>
+              <% user.stats.collectedTags.forEach((tag) => { %>
+                <% if (Object.keys(totalTags[display]['Units']).includes(tag)) { %>
+                  <button class="btn btn-primary text-sm py-1 px-2 cursor-default" disabled><%= tag %></button>
+                  <% counter++; %>
+                <% } else if (Object.keys(totalTags[display]['Concepts']).includes(tag)) { %>
+                  <button class="btn bg-cyan-500 hover:bg-cyan-500 text-white text-sm py-1 px-2 cursor-default" disabled><%= tag %></button>
+                  <% counter++; %>
+                <% } %>
+              <% }); %>
+            </div>
+            <% const totalCount = Object.keys(totalTags[display]['Units']).length + Object.keys(totalTags[display]['Concepts']).length %>
+            <% if (counter === 0) { %>
+              <p>0 out of <%= totalCount %> possible tags</p>
+            <% } else { %>
+              <p><%= counter %>/<%= totalCount %> tags in this subject have been collected</p>
+            <% } %>
+          <% } %>
+
+          <% [
+            ['Areas of Mastery',     analytics.strengths[akey]],
+            ['Currently Studying',   analytics.studying[akey]],
+            ['Recommended Training', analytics.weaknesses[akey]],
+            ['Favorite Units',       analytics.favorites[akey]],
+          ].forEach(([heading, units]) => { %>
+            <% if (units && units.length > 0) { %>
+              <h3 class="text-lg font-medium mt-3"><%= heading %>:</h3>
+              <div class="flex flex-wrap gap-2">
+                <% units.forEach((unit) => { %>
+                  <span class="px-3 py-1 bg-blue-500 text-white text-sm rounded-full"><%= unit.split(' ')[2] %></span>
+                <% }) %>
+              </div>
+            <% } %>
+          <% }) %>
+        </div>
+
+        <%# Right: rating tracker chart %>
+        <div class="lg:col-span-5 flex flex-col items-center">
+          <div class="w-full" style="height: 300px;">
+            <canvas id="ratingTrackerChart-<%= display %>"></canvas>
+          </div>
+          <input type="hidden" id="ratingTrackerArray-<%= display %>" value="<%= user.stats.ratingTracker[ratingKey].join('@') %>">
+        </div>
+
+      </div>
+
+      <a href="/train/<%= profPath %>/proficiency" class="btn btn-primary w-full">Change <%= display %> Proficiency</a>
+    </div>
+  <% }) %>
+
+  <%# Performance + site experience + rush %>
+  <div class="p-6 rounded-xl border-2 flex flex-col gap-4">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
+
+      <div class="lg:col-span-4 flex flex-col items-center">
+        <h2 class="text-center text-2xl mb-2">Performance</h2>
+        <div class="w-full" style="height: 300px;">
+          <canvas id="correctWrongChart"></canvas>
+        </div>
+        <input type="hidden" id="correctcount" value="<%= user.stats.correct %>">
+        <input type="hidden" id="wrongcount" value="<%= user.stats.wrong %>">
+      </div>
+
+      <div class="lg:col-span-8 flex flex-col gap-3">
+        <h2 class="text-center text-2xl">Site Experience</h2>
+        <h3 class="text-center text-lg" id="experience-global-rank">Global Rank: XXX</h3>
+
+        <div class="w-full h-5 rounded-full bg-neutral-200 overflow-hidden">
+          <div class="h-full bg-green-500 transition-all" style="width: <%= Math.round(100 * userLevel.remainder / userLevel.totalToNext) %>%"></div>
+        </div>
+        <p class="text-center text-sm">
+          <strong>Level <%= userLevel.level %></strong>
+          (<%= userLevel.remainder %>/<%= userLevel.totalToNext %> XP to Level <%= userLevel.level + 1 %>)
+        </p>
+
+        <hr class="border-neutral-200 my-2">
+
+        <h2 class="text-center text-2xl">Problem Rush</h2>
+        <h3 class="text-center text-lg" id="rush-global-rank">Global Rank: XXX</h3>
+
+        <div class="grid grid-cols-2 gap-4">
+          <h3 class="text-center text-lg">Attempts: <span class="text-green-600"><%= user.stats.rush.attempts ? user.stats.rush.attempts : 0 %></span></h3>
+          <h3 class="text-center text-lg">High Score: <span class="text-green-600"><%= user.stats.rush.highscore ? user.stats.rush.highscore : 0 %></span></h3>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary
Combines the next three batch-2 page migrations into a single PR for batch review. All three are independently reviewable as commits — see the commit list for the per-page split.

### Settings (commit `187999e`)
- `views/private/settingsV2.ejs` using `base.ejs` layout — Profile / Personalization / Account / Delete Account forms with Tailwind 12-col grids and native input styling
- Replace jQuery unsaved-changes detector with Alpine.js (already loaded by V2 head)
- Replace Bootstrap delete-confirm modal with an Alpine-driven custom modal
- Field names, IDs, and POST endpoints (`/changeProfile`, `/changePreferences`, `/changeSettings`, `/deleteAccount`) all preserved
- Wire `/settings` to V2 view via `expressLayouts`

### Leaderboard (commit `a8fc5ff`)
- `views/private/leaderboardV2.ejs` using `base.ejs` layout — rating leaderboard 4-col grid (Physics/Chemistry/Biology/USABO), Rush leaderboard, Experience leaderboard
- Consolidate four near-identical rating tables into a single `forEach` over `[title, list, valueGetter]` tuples
- Row colors (1st/2nd/3rd/4th+) and medal SVGs preserved
- Wire `/leaderboard` to V2 view via `expressLayouts`

### Stats (commit `dad3aea`) — largest page in batch 2 per #609
- `views/private/statsV2.ejs` using `base.ejs` layout — 5 subject sections (Physics/Chemistry/Biology/ESS/USABO) each with rating + global rank, collected tags (subjects with tags only — USABO has none), analytics groups (Areas of Mastery / Currently Studying / Recommended Training / Favorite Units), Chart.js rating tracker, Change Proficiency button; performance section with Chart.js correct/wrong pie + custom plugin, Tailwind site-experience bar, Problem Rush stats
- Consolidate 5 near-identical subject sections into a single `forEach` over a `[displayName, ratingKey, analyticsKey, proficiencyPath, hasTags]` config table; URL casing preserved (USABO stays uppercase in `/train/USABO/proficiency`)
- Wire `/stats/:username` (both teacher and self branches) to V2 view via `expressLayouts`

Part of the broader Tailwind V2 migration tracked in #609. Legacy `settings.ejs`, `leaderboard.ejs`, `stats.ejs` remain in tree until the final cleanup pass.

## Test plan

### Settings
- [ ] `/settings` loads at 1280px and 375px with no console errors
- [ ] Edit any field → orange "unsaved changes" alert appears
- [ ] Submit each form individually with valid + invalid data → success and error flashes both render in V2 styling
- [ ] Click "Delete Account" → modal appears → Cancel closes it; clicking Delete submits the form (test with a throwaway account)
- [ ] `view-source:/settings` contains exactly one `<head>` and one `<body>`

### Leaderboard
- [ ] `/leaderboard` loads at 1280px (4 columns side-by-side) and 375px (stacked)
- [ ] 1st/2nd/3rd row colors render (sky blue / yellow / red), 4th+ green; medal SVGs in ranks 1–3
- [ ] Click a username → `/profile/:username` opens in a new tab
- [ ] `view-source:/leaderboard` contains exactly one `<head>` and one `<body>`

### Stats
- [ ] `/stats` (your own) loads at 1280px and 375px with no console errors; 5 subject sections + performance section render
- [ ] After ~1s the global ranks fill in (replaces "XXX") for physics/chemistry/biology/experience/rush
- [ ] Correct/wrong pie chart renders with on-canvas Correct: %% / Wrong: %% labels via the custom plugin
- [ ] Each "Change &lt;Subject&gt; Proficiency" button links to `/train/<lowercase>/proficiency` (USABO uppercase)
- [ ] As a teacher, view a private student's stats and confirm the V2 page renders
- [ ] `view-source:/stats/:username` contains exactly one `<head>` and one `<body>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)